### PR TITLE
Added source and sourcens flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,26 @@ curl -s -L https://github.com/karmab/tasty/releases/latest/download/tasty-linux-
 chmod u+x /usr/bin/tasty
 ```
 
+### Some tasty install samples
+
+- Install OLM operators changing the sourceNamespace value
+
+```bash
+tasty install assisted-service-operator hive-operator --sourcens olm
+```
+
+- Install OLM operators changing the CatalogSource and sourceNamespace value
+
+```bash
+tasty install assisted-service-operator hive-operator --source certified-operators --sourcens olm
+```
+
+- Print yaml of OLM operator without install
+
+```bash
+tasty install assisted-service-operator
+```
+
 ## Requirements
 
 Kubeconfig environment variable must be set

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -22,10 +22,14 @@ import (
 )
 
 func NewInstaller() *cobra.Command {
-	var o *operator.Operator
-	var wait, out bool
-	var ns, ch string
-	var csv, installPlan string
+	var (
+		o                *operator.Operator
+		wait, out        bool
+		ns, ch           string
+		csv, installPlan string
+		src, srcNS       string
+	)
+
 	cmd := &cobra.Command{
 		Use:          "install [operator]",
 		Short:        "install operators",
@@ -33,7 +37,7 @@ func NewInstaller() *cobra.Command {
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			o = operator.NewOperator()
-			return o.InstallOperator(wait, out, ns, ch, csv, installPlan, args)
+			return o.InstallOperator(wait, out, ns, ch, csv, src, srcNS, installPlan, args)
 		},
 	}
 	flags := cmd.Flags()
@@ -41,7 +45,9 @@ func NewInstaller() *cobra.Command {
 	flags.BoolVarP(&out, "stdout", "s", false, "Print to stdout")
 	flags.StringVarP(&ns, "namespace", "n", "", "Target namespace")
 	flags.StringVarP(&ch, "channel", "c", "", "Target channel")
-	flags.StringVarP(&csv, "csv", "", "", "Custom csv")
+	flags.StringVar(&csv, "csv", "", "Custom csv")
+	flags.StringVar(&src, "source", "community-operators", "CatalogSource to be used")
+	flags.StringVar(&srcNS, "sourcens", "openshift-marketplace", "Source namespace to grab the CatalogSource")
 	flags.StringVarP(&installPlan, "installplan", "", "", "installPlan")
 
 	return cmd

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -3,6 +3,7 @@ package operator
 type Operator struct {
 	Name           string
 	Source         string
+	SourceNS       string
 	DefaultChannel string
 	Description    string
 	Csv            string
@@ -17,6 +18,7 @@ func NewOperator() *Operator {
 	return &Operator{
 		Name:           "",
 		Source:         "",
+		SourceNS:       "",
 		DefaultChannel: "",
 		Description:    "",
 		Csv:            "",
@@ -28,10 +30,11 @@ func NewOperator() *Operator {
 	}
 }
 
-func NewOperatorWithOptions(name, source, defaultChannel, description, csv, namespace, crd, configExecFile, configExecPath string) *Operator {
+func NewOperatorWithOptions(name, source, sourceNS, defaultChannel, description, csv, namespace, crd, configExecFile, configExecPath string) *Operator {
 	return &Operator{
 		Name:           name,
 		Source:         source,
+		SourceNS:       sourceNS,
 		DefaultChannel: defaultChannel,
 		Description:    description,
 		Csv:            csv,
@@ -72,7 +75,7 @@ spec:
   channel: "{{ .DefaultChannel }}"
   name: {{ .Name }}
   source: {{ .Source }}
-  sourceNamespace: openshift-marketplace
+  sourceNamespace: {{ .SourceNS }}
   startingCSV: {{ .Csv }}
   installPlanApproval: Automatic
 `


### PR DESCRIPTION
## Patch Content

- The source flag changes the default value of the CatalogSource in the final Subscription manifest.
- The sourcens flag changes the default namespace where the OLM operator grabs the catalogSource.
- Added a couple quality of life details to continue if the Namespace or the OperatorGroup already exists